### PR TITLE
Contributing file no longer is added to .github dir

### DIFF
--- a/provisioning/roles/developer/files/.git-shellrc
+++ b/provisioning/roles/developer/files/.git-shellrc
@@ -6,7 +6,7 @@ function gen::git::ignore() {
 
 function gen::git::contributing() {
   mkdir -p ./.github
-  cp "${template_dir}"/CONTRIBUTING.md ./.github
+  cp "${template_dir}"/CONTRIBUTING.md .
 }
 
 function gen::git::issue() {


### PR DESCRIPTION
### Description of Changes
Contributing file should not go into the .github dir in the repo.